### PR TITLE
Makes it possible to delete to connection between a resource and category

### DIFF
--- a/backend/app/resources/ResourceAndCategoryEndoint.py
+++ b/backend/app/resources/ResourceAndCategoryEndoint.py
@@ -3,25 +3,26 @@ from flask import request
 
 from app import db, RestException
 from app.model.resource_category import ResourceCategory
-from app.resources.schema import CategorySchema, ThrivResourceSchema, ResourceCategorySchema
+from app.resources.schema import CategorySchema, ThrivResourceSchema, ResourceCategorySchema, CategoryResourcesSchema, \
+    ResourceCategoriesSchema
 
 
 class ResourceByCategoryEndpoint(flask_restful.Resource):
-    schema = ThrivResourceSchema()
+
+    schema = CategoryResourcesSchema()
 
     def get(self, category_id):
         resource_categories = db.session.query(ResourceCategory).filter(ResourceCategory.category_id == category_id).all()
-        resources = [rc.resource for rc in resource_categories]
-        return self.schema.dump(resources,many=True)
+        return self.schema.dump(resource_categories,many=True)
 
 
 class CategoryByResourceEndpoint(flask_restful.Resource):
-    schema = CategorySchema()
+
+    schema = ResourceCategoriesSchema()
 
     def get(self, resource_id):
         resource_categories = db.session.query(ResourceCategory).filter(ResourceCategory.resource_id == resource_id).all()
-        categories = [rc.category for rc in resource_categories]
-        return self.schema.dump(categories,many=True)
+        return self.schema.dump(resource_categories,many=True)
 
 
 class ResourceCategoryEndpoint(flask_restful.Resource):

--- a/backend/app/resources/schema.py
+++ b/backend/app/resources/schema.py
@@ -28,7 +28,6 @@ class AvailabilitySchema(ModelSchema):
         fields = ('id', 'institution_id', 'resource_id', 'viewable', 'available', 'institution')
     institution = fields.Nested(ThrivInstitutionSchema(), dump_only=True, allow_none=True)
 
-
 class ThrivResourceSchema(ModelSchema):
     class Meta:
         model = ThrivResource
@@ -73,6 +72,7 @@ class IconSchema(ModelSchema):
         model = Icon
         fields = ('id', 'name', 'url')
 
+
 class CategorySchema(ModelSchema):
     """Provides detailed information about a category, including all the children"""
     class Meta:
@@ -81,7 +81,8 @@ class CategorySchema(ModelSchema):
                   'color', 'image', 'icon_id', 'icon',
                   'children', 'parent_id', 'parent', '_links')
     id = fields.Integer(required=False, allow_none=True)
-    icon = fields.Nested(IconSchema, dump_only=True)
+    icon_id = fields.Integer(required=False, allow_none=True)
+    icon = fields.Nested(IconSchema,  allow_none=True, dump_only=True)
     image = fields.String(required=False, allow_none=True)
     parent_id = fields.Integer(required=False, allow_none=True)
     children = fields.Nested('self', many=True, dump_only=True)
@@ -94,13 +95,38 @@ class CategorySchema(ModelSchema):
     })
 
 
+class ResourceCategoriesSchema(ModelSchema):
+    class Meta:
+        model = ResourceCategory
+        fields = ('id', '_links', 'category')
+    category = fields.Nested(CategorySchema, dump_only=True)
+    _links = ma.Hyperlinks({
+        'self': ma.URLFor('resourcecategoryendpoint', id='<id>'),
+        'category': ma.URLFor('categoryendpoint', id='<category_id>'),
+        'resource': ma.URLFor('resourceendpoint', id='<resource_id>')
+    })
+
+
+class CategoryResourcesSchema(ModelSchema):
+    class Meta:
+        model = ResourceCategory
+        fields = ('id', '_links', 'resource')
+    resource = fields.Nested(ThrivResourceSchema, dump_only=True)
+    _links = ma.Hyperlinks({
+        'self': ma.URLFor('resourcecategoryendpoint', id='<id>'),
+        'category': ma.URLFor('categoryendpoint', id='<category_id>'),
+        'resource': ma.URLFor('resourceendpoint', id='<resource_id>')
+    })
+
+
 class ResourceCategorySchema(ModelSchema):
     class Meta:
         model = ResourceCategory
-        fields = ('id', 'resource_id', 'category_id', '_links')
+        fields = ('id', '_links', 'resource_id', 'category_id')
     _links = ma.Hyperlinks({
         'self': ma.URLFor('resourcecategoryendpoint', id='<id>'),
-        'category': ma.URLFor('categoryendpoint', id='<category_id>')
+        'category': ma.URLFor('categoryendpoint', id='<category_id>'),
+        'resource': ma.URLFor('resourceendpoint', id='<resource_id>')
     })
 
 

--- a/backend/tests.py
+++ b/backend/tests.py
@@ -233,52 +233,6 @@ class TestCase(unittest.TestCase):
         self.assertEqual(response["_links"]["self"], '/api/resource/1')
         self.assertEqual(response["_links"]["collection"], '/api/resource')
 
-    def test_resource_set_icon(self):
-        self.construct_resource()
-
-        rv = self.app.get('/api/resource/1',
-                          follow_redirects=True,
-                          content_type="application/json")
-        self.assertSuccess(rv)
-        response = json.loads(rv.get_data(as_text=True))
-        self.assertIsNone(response['icon_id'])
-
-        rv = self.app.post('/api/resource/1/icon',
-                           content_type="application/json")
-        self.assertSuccess(rv)
-        response = json.loads(rv.get_data(as_text=True))
-        self.assertIn('upload_post_args', response)
-
-        rv = self.app.get('/api/resource/1',
-                          follow_redirects=True,
-                          content_type="application/json")
-        self.assertSuccess(rv)
-        response = json.loads(rv.get_data(as_text=True))
-        self.assertIsNotNone(response['icon_id'])
-
-    def test_resource_set_header(self):
-        self.construct_resource()
-
-        rv = self.app.get('/api/resource/1',
-                          follow_redirects=True,
-                          content_type="application/json")
-        self.assertSuccess(rv)
-        response = json.loads(rv.get_data(as_text=True))
-        self.assertIsNone(response['header_id'])
-
-        rv = self.app.post('/api/resource/1/header',
-                           content_type="application/json")
-        self.assertSuccess(rv)
-        response = json.loads(rv.get_data(as_text=True))
-        self.assertIn('upload_post_args', response)
-
-        rv = self.app.get('/api/resource/1',
-                          follow_redirects=True,
-                          content_type="application/json")
-        self.assertSuccess(rv)
-        response = json.loads(rv.get_data(as_text=True))
-        self.assertIsNotNone(response['header_id'])
-
     def test_category_has_links(self):
         self.construct_category()
         rv = self.app.get('/api/category/1',
@@ -583,7 +537,7 @@ class TestCase(unittest.TestCase):
         response = json.loads(rv.get_data(as_text=True))
         self.assertEquals(1, len(response))
         self.assertEquals(r.id, response[0]["id"])
-        self.assertEquals(r.description, response[0]["description"])
+        self.assertEquals(r.description, response[0]["resource"]["description"])
 
     def test_get_category_by_resource(self):
         c = self.construct_category()
@@ -596,7 +550,7 @@ class TestCase(unittest.TestCase):
         response = json.loads(rv.get_data(as_text=True))
         self.assertEquals(1, len(response))
         self.assertEquals(c.id, response[0]["id"])
-        self.assertEquals(c.description, response[0]["description"])
+        self.assertEquals(c.description, response[0]["category"]["description"])
 
     def test_add_category_to_resource(self):
         c = self.construct_category()
@@ -621,15 +575,13 @@ class TestCase(unittest.TestCase):
 
     def test_create_category(self):
         c = {"name":"Old bowls", "description":"Funky bowls of yuck still on my desk. Ews!",
-             "color": "#000", "brief_description":"Funky Bowls!", "image":"image.png",
-             "icon":"icon.png"}
+             "color": "#000", "brief_description":"Funky Bowls!", "image":"image.png"}
         rv = self.app.post('/api/category', data=json.dumps(c), content_type="application/json")
         self.assertSuccess(rv)
         response = json.loads(rv.get_data(as_text=True))
         self.assertEquals(c["name"], response["name"])
         self.assertEquals(c["description"], response["description"])
         self.assertEquals(c["brief_description"], response["brief_description"])
-        self.assertEquals(c["icon"], response["icon"])
         self.assertEquals(c["color"], response["color"])
         self.assertEquals(c["image"], response["image"])
 
@@ -701,21 +653,6 @@ class TestCase(unittest.TestCase):
         self.assertSuccess(rv)
         data = json.loads(rv.get_data(as_text=True))
         self.assertEqual("https://s3.amazonaws.com/edplatform-ithriv-test-bucket/ithriv/icon/%i.svg" % icon_id, data["url"])
-
-
-    def test_upload_category_image(self):
-        category = Category(name= "Bird Babies", description = "A sub category of nonsense that happens on my patio", color="#A52A2A")
-        db.session.add(category)
-        db.session.commit()
-
-        rv = self.app.post('/api/category/%s/image' % category.id,
-            data=dict(
-                image=(BytesIO(b"hi everyone"), 'test.png'),
-            ))
-        self.assertSuccess(rv)
-        data = rv.get_data(as_text=True)
-        self.assertEqual("https://s3.amazonaws.com/edplatform-ithriv-test-bucket/ithriv/category/image/%i.png" % category.id,
-                          data)
 
     def test_set_category_icon(self):
         category = Category(name="City Museum", description="A wickly cool amazing place in St Louis",

--- a/frontend/src/app/category-resource.ts
+++ b/frontend/src/app/category-resource.ts
@@ -1,0 +1,14 @@
+import { Availability } from './availability';
+import { Institution } from './institution';
+import { Links } from './links';
+import { ResourceType } from './resourceType';
+import { Type } from '@angular/compiler/src/output/output_ast';
+import {Resource} from './resource';
+import {Category} from './category';
+
+export interface CategoryResource {
+  id: number;
+  resource: Resource;
+  category: Category;
+  _links?: Links;
+}

--- a/frontend/src/app/category/category.component.html
+++ b/frontend/src/app/category/category.component.html
@@ -5,5 +5,5 @@
     </button>
   </h1>
 
-  <app-resource-list [resources]="resources"></app-resource-list>
+  <app-resource-list [resources]="resources()"></app-resource-list>
 </div>

--- a/frontend/src/app/category/category.component.ts
+++ b/frontend/src/app/category/category.component.ts
@@ -5,6 +5,7 @@ import { Category } from '../category';
 import { Resource } from '../resource';
 import { ResourceApiService } from '../resource-api.service';
 import { ResourceFormComponent } from '../resource-form/resource-form.component';
+import {CategoryResource} from '../category-resource';
 
 @Component({
   selector: 'app-category',
@@ -14,7 +15,7 @@ import { ResourceFormComponent } from '../resource-form/resource-form.component'
 export class CategoryComponent implements OnInit {
   categoryId: number;
   category: Category;
-  resources: Resource[];
+  categoryResources: CategoryResource[];
   isDataLoaded = false;
 
   constructor(
@@ -40,11 +41,19 @@ export class CategoryComponent implements OnInit {
 
   loadResources() {
     this.api.getCategoryResources(this.category).subscribe(
-      (resources) => {
-        this.resources = resources;
+      (categoryResources) => {
+        this.categoryResources = categoryResources;
         this.isDataLoaded = true;
       }
     );
+  }
+
+  resources() {
+    const resources = [];
+    for (const categoryResource of this.categoryResources) {
+      resources.push(categoryResource.resource);
+    }
+    return resources
   }
 
   openEdit(resource: Resource, parent: Category = null) {

--- a/frontend/src/app/resource-api.service.ts
+++ b/frontend/src/app/resource-api.service.ts
@@ -7,6 +7,7 @@ import { Category } from './category';
 import { Resource } from './resource';
 import { ResourceCategory } from './resource-category';
 import { ResourceQuery } from './resource-query';
+import {CategoryResource} from './category-resource';
 
 @Injectable()
 export class ResourceApiService {
@@ -56,8 +57,8 @@ export class ResourceApiService {
       .pipe(catchError(this.handleError));
   }
 
-  getCategoryResources(category: Category): Observable<Resource[]> {
-    return this.httpClient.get<Resource[]>(this.apiRoot + category._links.resources)
+  getCategoryResources(category: Category): Observable<CategoryResource[]> {
+    return this.httpClient.get<CategoryResource[]>(this.apiRoot + category._links.resources)
       .pipe(catchError(this.handleError));
   }
 


### PR DESCRIPTION
This creates a light wrapper around records returned from the /api/resource_category, /api/category/<id>/resource and /api/resource/<id>category endpoints so you can more easily create and destroy this relationship with the basic REST based calls.

I've made slight modifications to the front end code so this doesn't break front end features.  